### PR TITLE
Instead of the "Could not complete payment" error in Apple pay (possibly in Google Pay as well), the payment will be confirmed.

### DIFF
--- a/device_nfc.cpp
+++ b/device_nfc.cpp
@@ -18,7 +18,8 @@ std::map<unsigned short, byte_t const *> DeviceNFC::PDOLValues = {
     {0x9A,   new byte_t[3]{0x19, 0x01, 0x01}}, // Transaction Date
     {0x9C,   new byte_t[1]{0x00}},             // Transaction Type
     {0x98,   new byte_t[20]{0}},             // Transaction Cert
-    {0x9F37, new byte_t[4]{0x82, 0x3D, 0xDE, 0x7A}} // Unpredictable number
+    {0x9F37, new byte_t[4]{0x82, 0x3D, 0xDE, 0x7A}}, // Unpredictable number
+    {0x9F66, new byte_t[4]{0xC8, 0x80, 0x00, 0x00}} // Terminal Transaction Qualifiers (TTQ) 
 };
 
 


### PR DESCRIPTION
## **Before:**
![147664570-fcdf5baf-3d72-4b94-82e5-10bab08dd5d71 (2)](https://user-images.githubusercontent.com/34600049/164985857-8fe87fef-06ca-491f-ba91-b2e8b8848098.png)

## **After:**
![147697997-3dba815c-6a4e-4a80-bfa4-e49f19cf1781](https://user-images.githubusercontent.com/34600049/164985921-1c04d2ac-2861-400c-80b6-b6c93a1c6c1b.png)


